### PR TITLE
fix(app): variant images from shopify and styling details accordion

### DIFF
--- a/app/src/components/Accordion/styled.tsx
+++ b/app/src/components/Accordion/styled.tsx
@@ -22,7 +22,7 @@ export const ToggleButton = styled.button`
       display: block;
       position: absolute;
       right: 0;
-      top: -2px;
+      top: -16px;
       font-size: 15px;
   `}
 `

--- a/app/src/components/ContentBlock/ContentBlock.tsx
+++ b/app/src/components/ContentBlock/ContentBlock.tsx
@@ -7,6 +7,7 @@ import {
 import { ImageTextBlock } from './ImageTextBlock'
 import { HeroBlock } from './HeroBlock'
 import { CarouselBlock } from './CarouselBlock'
+import { ImageWithoutText } from './ImageWithoutText'
 
 interface ContentBlockProps {
   content: ImageTextBlockType | Hero | Carousel
@@ -22,6 +23,11 @@ export const ContentBlock = ({ content }: ContentBlockProps) => {
       return (
         //
         <ImageTextBlock content={content} />
+      )
+    case 'Image':
+      return (
+        //
+        <ImageWithoutText content={content} />
       )
     case 'Hero':
       return (

--- a/app/src/components/ContentBlock/ImageTextBlock.tsx
+++ b/app/src/components/ContentBlock/ImageTextBlock.tsx
@@ -21,7 +21,7 @@ export const ImageTextBlock = (props: ImageTextBlockProps) => {
   }
 
   const link = content.link ? content.link[0] : undefined
-  console.log(content)
+
   return (
     <PageLink link={link}>
       <ImageText textAlign={content.textPosition}>

--- a/app/src/components/ContentBlock/ImageWithoutText.tsx
+++ b/app/src/components/ContentBlock/ImageWithoutText.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { Placeholder } from '../Placeholder'
+import { ImageTextBlock as ImageTextBlockType } from '../../types'
+import { ImageText, TextOverImage } from '../Layout/index'
+import { RichText } from '../RichText'
+import { PageLink } from '../PageLink'
+import { Image } from '../Image'
+import { getPageLinkUrl } from '../../utils/links'
+
+interface ImageWithoutText {
+  content: ImageWithoutText
+}
+
+export const ImageWithoutText = (props: ImageWithoutText) => {
+  let content = props.content
+  return (
+    <PageLink>
+      <ImageText>
+        <img src={content.originalSrc} />
+      </ImageText>
+    </PageLink>
+  )
+}

--- a/app/src/components/Layout/Containers.tsx
+++ b/app/src/components/Layout/Containers.tsx
@@ -87,6 +87,7 @@ export const ImageText = styled.div`
       background-position: center;
       vertical-align: top;
       position: relative;
+      line-height: 0;
       ${theme.mediaQueries.tablet} {
         width: 100%;
       }
@@ -115,6 +116,7 @@ export const TextOverImage = styled.div`
         position: absolute;
         width: 100%;
         padding: ${theme.layout.spacing.triple};
+        line-height: initial;
         padding-top: ${
           textAlign === 'middle-center' ? '45%' : theme.layout.spacing.triple
         };

--- a/app/src/components/Layout/Flex.tsx
+++ b/app/src/components/Layout/Flex.tsx
@@ -42,6 +42,7 @@ export const FlexContainer = styled.div`
 		margin-right: ${align ? 'auto' : 'initial'};
     padding: ${theme.layout.spacing[padding] || 'initial'}; 
     background-color: ${backgroundColor};
+    align-items: baseline;
 	`}
   .visible {
     opacity: 1;

--- a/app/src/components/Text.tsx
+++ b/app/src/components/Text.tsx
@@ -22,6 +22,7 @@ const commonHeaderStyles = ({
   margin,
   children,
   small,
+  active,
 }: TextStyleProps) => css`
   font-weight: ${theme.font.weight[weight]
     ? theme.font.weight[weight]
@@ -34,7 +35,7 @@ const commonHeaderStyles = ({
   text-transform: ${transform || 'auto'};
   margin: ${margin || '0.3em 0'};
   letter-spacing: 0.75px;
-
+  border-bottom: ${active ? '1px solid black' : 'inherit'};
   p {
     letter-spacing: 1px;
   }

--- a/app/src/views/ProductDetail/ProductDetail.tsx
+++ b/app/src/views/ProductDetail/ProductDetail.tsx
@@ -67,6 +67,9 @@ const ProductDetailMain = ({ product, productExtra }: Props) => {
   const { addItemToCheckout } = useCheckout()
   const [variants] = unwindEdges<Variant>(product.variants)
 
+  /* get product image variants from Shopify */
+  let { images } = product
+
   return (
     <Wrapper backgroundColor={'#F5F3F4'}>
       <Column>
@@ -79,16 +82,8 @@ const ProductDetailMain = ({ product, productExtra }: Props) => {
               currentVariant={currentVariant}
               product={product}
             />
-            <ProductVariantSelector
-              setQuantity={setQuantity}
-              quantity={quantity}
-              increment={increment}
-              decrement={decrement}
-              variants={variants}
-              currentVariant={currentVariant}
-              selectVariant={selectVariant}
-            />
-            <NormalizeDiv>
+
+            <NormalizeDiv margin="0 0 20px 0">
               <BuyButton
                 addItemToCheckout={addItemToCheckout}
                 currentVariant={currentVariant}
@@ -99,11 +94,24 @@ const ProductDetailMain = ({ product, productExtra }: Props) => {
                 ? info.map((a) => <Accordion key={a._key} content={a} />)
                 : null}
             </NormalizeDiv>
+            <ProductVariantSelector
+              setQuantity={setQuantity}
+              quantity={quantity}
+              increment={increment}
+              decrement={decrement}
+              variants={variants}
+              currentVariant={currentVariant}
+              selectVariant={selectVariant}
+            />
           </ProductInfoWrapper>
         </ProductDetails>
       </Column>
-      <ProductDetailFooter product={product} content={productExtra} />
+      {/* Shopify alt images will go here */}
+      <ProductDetailFooter product={product} content={images} />
+      {/* Related Products */}
       <ProductRelated product={product} />
+      {/* This is currently  from sanity */}
+      <ProductDetailFooter product={product} content={productExtra} />
     </Wrapper>
   )
 }

--- a/app/src/views/ProductDetail/components/ProductDetailFooter.tsx
+++ b/app/src/views/ProductDetail/components/ProductDetailFooter.tsx
@@ -22,6 +22,12 @@ export const ProductDetailFooter = ({
         ? content.contentAfter.map((content, index) => (
             <ContentBlock content={content} />
           ))
+        : content.edges
+        ? content.edges.map((content, index) => {
+            if (index > 0) {
+              return <ContentBlock content={content.node} />
+            }
+          })
         : null}
     </NormalizeDiv>
   )

--- a/app/src/views/ProductDetail/components/ProductRelated.tsx
+++ b/app/src/views/ProductDetail/components/ProductRelated.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import { Product, Collection } from '../../../types/generated'
 import { unwindEdges } from '../../../utils/graphql'
 import { ProductRelatedWrapper, ProductRelatedInner } from '../styled'
 import { Carousel } from 'Components/Carousel'
 import { Header2, Header4 } from 'Components/Text'
-import { Image } from 'Components/Image'
-import { Figure } from 'Components/Figure'
 import { ProductThumbnail } from '../../ProductListing/ProductThumbnail'
+import { FlexContainer } from '../../../components/Layout'
 
 interface ProductRelatedProps {
   product: Product
@@ -20,9 +18,27 @@ export const ProductRelated = ({ product }: ProductRelatedProps) => {
   if (!products || !products.length) return null
   return (
     <ProductRelatedWrapper>
-      <Header2 transform="capitalize" size="small" color="dark" align="center">
-        Shop the {collections[0].title} Collection
-      </Header2>
+      <FlexContainer center="center">
+        <Header4
+          active
+          margin="10px"
+          transform="capitalize"
+          size="small"
+          color="dark"
+          align="center"
+        >
+          More Like this
+        </Header4>
+        <Header4
+          margin="10px"
+          transform="capitalize"
+          size="small"
+          color="dark"
+          align="center"
+        >
+          Best Selling {collections[0].title}
+        </Header4>
+      </FlexContainer>
       <ProductRelatedInner>
         <Carousel>
           {products.slice(0, 10).map((product) => {

--- a/app/src/views/ProductDetail/components/ProductVariantSelector.tsx
+++ b/app/src/views/ProductDetail/components/ProductVariantSelector.tsx
@@ -35,10 +35,9 @@ export const ProductVariantSelector = (props: Props) => {
     selectVariant(e.target.value)
   }
   const handleQuantityInput = (e) => setQuantity(e.target.value)
-
   return (
     <div>
-      <NormalizeDiv>
+      <NormalizeDiv margin="20px 0">
         <Accordion label={'Size'} content={'dummyContent'} />
         {/* <Label>Size</Label> */}
         {/* <Select


### PR DESCRIPTION
- Adding variant images for the product detail page (this will need to be updated so its working properly but getting the details there)

- styled related headers
- re organizing some details of the page