### PR TITLE
fix(app): hide VariantSelector on products with only one variant

### DIFF
--- a/app/src/graphql/fragments/shopify.ts
+++ b/app/src/graphql/fragments/shopify.ts
@@ -96,6 +96,7 @@ export const variantWithProductFragment = gql`
     image {
       ...ImageFragment
     }
+    availableForSale
     requiresShipping
     selectedOptions {
       __typename

--- a/app/src/views/ProductDetail/components/ProductVariantSelector.tsx
+++ b/app/src/views/ProductDetail/components/ProductVariantSelector.tsx
@@ -55,7 +55,7 @@ export const ProductVariantSelector = (props: Props) => {
           (option) => !Boolean(option.name === 'Size' && inquiryOnly === true),
         )
         .map((option) =>
-          option?.values && option.values.length > 0 ? (
+          option?.values && option.values.length > 1 ? (
             <OptionWrapper key={option._key || 'some-key'}>
               <ProductOptionSelector
                 changeValueForOption={changeValueForOption}


### PR DESCRIPTION
reverting to previous UX