### PR TITLE
fix(sanity): refactor journal pane to avoid weird listenQuery bug

### DIFF
--- a/sanity/schemas/documents/journal.js
+++ b/sanity/schemas/documents/journal.js
@@ -74,4 +74,14 @@ export const journal = {
       media: thumbnail,
     }),
   },
+  orderings: [
+    {
+      title: 'Publish Date',
+      name: 'publishDateDesc',
+      by: [
+        { field: 'publishDate', direction: 'desc' },
+        { field: '_createdAt', direction: 'desc' },
+      ],
+    },
+  ],
 }

--- a/sanity/schemas/structure.js
+++ b/sanity/schemas/structure.js
@@ -106,63 +106,14 @@ export default () =>
         .id('journal')
         .icon(FaPencilAlt)
         .child(
-          documentStore
-            .listenQuery(
-              `
-              *[_type == "journalEntry" && !(_id in path("drafts.**"))]
-              | order(coalesce(publishDate, _createdAt) desc)
-              {
-                _id,
-                _type,
-                title
-              }`,
-            )
-            .pipe(
-              map((journalEntries) =>
-                S.list()
-                  .title('Journal')
-                  .items([
-                    S.listItem()
-                      .title('Journal (Main Page)')
-                      .icon(AiOutlineBook),
-                    S.divider(),
-                    ...journalEntries.map((entry) =>
-                      S.documentListItem()
-                        .schemaType('journalEntry')
-                        .id(entry._id)
-                        .icon(FaPencilAlt)
-                        .child(
-                          S.editor()
-                            .id(entry._id)
-                            .schemaType(entry._type)
-                            .documentId(entry._id),
-                        ),
-                    ),
-                  ]),
-              ),
-            ),
+          S.list()
+            .title('Journal')
+            .items([
+              S.listItem().title('Journal (Main Page)').icon(AiOutlineBook),
+              S.divider(),
+              S.documentTypeListItem('journalEntry'),
+            ]),
         ),
-      // S.listItem()
-      //   .title('Journal (Main Page)')
-      //   .icon(FaPencilAlt)
-      //   .child(
-      //     S.editor()
-      //       .id('journalPage')
-      //       .schemaType('journalPage')
-      //       .documentId('journalPage'),
-      //   ),
-      //
-      // S.listItem()
-      //   .id('journal')
-      //   .title('Journal')
-      //   .icon(FaPencilAlt)
-      //   .child(S.documentTypeList('journalEntry')),
-
-      // Page Directories
-      // S.listItem()
-      //   .title('Directory Pages')
-      //   .icon(ImFilesEmpty)
-      //   .child(S.documentTypeList('directory')),
 
       S.listItem()
         .title('About (Main Page)')

--- a/sanity/schemas/structure.js
+++ b/sanity/schemas/structure.js
@@ -109,9 +109,19 @@ export default () =>
           S.list()
             .title('Journal')
             .items([
-              S.listItem().title('Journal (Main Page)').icon(AiOutlineBook),
+              S.listItem()
+                .title('Journal (Main Page)')
+                .icon(AiOutlineBook)
+                .child(
+                  S.editor()
+                    .id('journalPage')
+                    .schemaType('journalPage')
+                    .documentId('journalPage'),
+                ),
               S.divider(),
-              S.documentTypeListItem('journalEntry'),
+              S.documentTypeListItem('journalEntry')
+                .title('Journal Entries')
+                .icon(FaPencilAlt),
             ]),
         ),
 


### PR DESCRIPTION
The `intent=...` resolver was choking on our **Journal (Main Page)** structure, because it was missing a `.child(S.editor(...))`. I suppose the resolver runs through all available panes to see if it matches the document from the `intent=...` and compares them - but it was getting stuck when there was nothing to compare for the journal page.

I initially though it was an issue with the usage `listenQuery`. It wasn't, but that was causing the same loading issues that you mentioned, so this just sticks Journal Entries into a second level in the studio:

![image](https://user-images.githubusercontent.com/11514928/145129040-66131481-5e71-460d-8619-7dd6d2724687.png)

